### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rockminster/FreeState-FreeUI/security/code-scanning/2](https://github.com/rockminster/FreeState-FreeUI/security/code-scanning/2)

To address the issue, add a `permissions` block specifying minimal required access for the workflow. The best location is at the root of the workflow file, so all jobs inherit these restricted permissions unless overridden locally. Edit `.github/workflows/ci.yml`—preferably immediately after the name and before `on:`—by inserting:

```yaml
permissions:
  contents: read
```

This restricts the GITHUB_TOKEN to read-only access to repository contents, sufficient for checking out code and caching but disallows write actions on issues, pull requests, etc. No additional imports or method changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
